### PR TITLE
Fix global ESLint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - "7"
 cache: yarn
 script:
-  - eslint .
+  - yarn lint

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ We use Semantic Versioning for maintaining versions for the git tag and npm pack
 In order to help you decide which version to bump to, issues will be labelled appropriately as far as possible.
 
 ### Code styling
-We use [ESLint](http://eslint.org) for linting our codebase. Run `eslint .` for checking lint errors. Most common errors can be fixed by running `eslint --fix .`. Code styling is an important part of writing good code to the make the code more readable and meaningful. We follow the latest ES6 standards for our codebase. Make sure you run the lint checks before submitting a PR so that there are no CI build failures.  
+We use [ESLint](http://eslint.org) for linting our codebase. Run `yarn lint` or `npm run-script lint` for checking lint errors. Most common errors can be fixed by running `yarn lint-fix` or `npm run-script lint-fix`. Code styling is an important part of writing good code to the make the code more readable and meaningful. We follow the latest ES6 standards for our codebase. Make sure you run the lint checks before submitting a PR so that there are no CI build failures.  

--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "lint-fix": "./node_modules/.bin/eslint --fix ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotsbot",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A bot for Public Lab",
   "main": "bot.js",
   "repository": "git@github.com:publiclab/plotsbot.git",


### PR DESCRIPTION
We should avoid using ESLint globally and use the copy we added to devDependencies instead. As the devDependencies ESLint is inside the `node_modules` folder, the command changes from the simple `eslint .` to the more complicated `./node_modules/.bin/eslint .`. Therefore, I found it easier to add a lint script in the package.json which can be executed by simply running `yarn lint`.