### PR TITLE
Fix join handler to use the immediate method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotsbot",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "A bot for Public Lab",
   "main": "bot.js",
   "repository": "git@github.com:publiclab/plotsbot.git",

--- a/services/chatbot.js
+++ b/services/chatbot.js
@@ -16,7 +16,7 @@ class Chatbot {
 
   addListeners () {
     this.client.addJoinHandler((channel, nick) => {
-      this.client.sendMessage(channel, `Welcome to Publiclab, ${nick}! For a \
+      this.sendMessage(this.nick, channel, `Welcome to Publiclab, ${nick}! For a \
 quick walkthrough, send the message: \`${this.nick} help\``);
     });
 


### PR DESCRIPTION
I feel that we should use `this.sendMessage` instead of `this.client.sendMessage` in the join handler. This is debatable though. @publiclab/soc feedback?

This would also work well because I plan to test the joinHandler by manually emitting the `join` event and using spies to check if the sendMessage method was called.