### PR TITLE
[WIP] FTO behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,17 @@ help
     1. `channel: String` => This is the name of the channel on which the user joined.
     2. `username: String` => This is the username of the new user.
     3. `botNick: String` => This is the username of the bot.
-
     On the other hand, for behaviors with `trigger` equal to `message`, the bot passes two arguments to the action function. These are:
-
     1. `botNick: String` => This is the username of the bot.
     2. `options: Array` => This is an array containing additional options provided by the user.
+This function may return a result string which will be sent back to the user in a message, or a promise that will eventually yield such a string.
 3. `keyword: String` **(Only required for message triggered behaviors)** => This is the keyword that must be present in the message in order for the bot to call the behavior's action function.
 
 ## Behaviors
 
 Behaviors are clearly defined tasks performed by the bot. A behavior may use any third-party functions to perform this action, but it needs to expose a few mandatory fields that are used by the chatbot to trigger the behavior at the appropriate time.
+
+A behavior may export an object of type `Behavior` or a factory function that returns such an object. These factory functions come into play when you want a shared state between multiple behaviors. For example: If you have multiple behaviors that make use of a database, there is no need to get a database connection individually for each such behavior.
 
 ### Greet
 `trigger` **join**
@@ -72,6 +73,12 @@ The bot greets users when they join the channel.
 `keyword` **help**
 
 Prints out the help messages of the modules whose names have been specified. If no modules were mentioned, all modules are explained.
+
+### First Timers Only
+`trigger` **message**
+`keyword` **fto**
+
+Prints out all the issues in the specified publiclab repositories labelled 'first-timers-only'. If no repositories are mentioned, the user is asked to do so.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,18 @@ help
 
 1. `trigger: String` => The event on which the behavior is supposed to be triggered. Currently, two events are supported - the `join` event which is triggered whenever a new user joins a particular channel, and the `message` event whenever a particular user sends a message on a channel.
 2. `action: Function` => This is the action of the behavior which is called by the bot at the appropriate moment. The bot provides the function with different arguments depending on the corresponding behavior's `trigger` value. For behaviors with `trigger` equal to `join`, the bot passes three arguments to the action function upon trigger. These are:
+
     1. `channel: String` => This is the name of the channel on which the user joined.
     2. `username: String` => This is the username of the new user.
     3. `botNick: String` => This is the username of the bot.
+
     On the other hand, for behaviors with `trigger` equal to `message`, the bot passes two arguments to the action function. These are:
+
     1. `botNick: String` => This is the username of the bot.
     2. `options: Array` => This is an array containing additional options provided by the user.
-This function may return a result string which will be sent back to the user in a message, or a promise that will eventually yield such a string.
+
+    This function may return a result string which will be sent back to the user in a message, or a promise that will eventually yield such a string.
+
 3. `keyword: String` **(Only required for message triggered behaviors)** => This is the keyword that must be present in the message in order for the bot to call the behavior's action function.
 
 ## Behaviors
@@ -75,7 +80,7 @@ The bot greets users when they join the channel.
 Prints out the help messages of the modules whose names have been specified. If no modules were mentioned, all modules are explained.
 
 ### First Timers Only
-`trigger` **message**
+`trigger` **message**  
 `keyword` **fto**
 
 Prints out all the issues in the specified publiclab repositories labelled 'first-timers-only'. If no repositories are mentioned, the user is asked to do so.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Ujjwal Sharma",
   "license": "GPL-3.0",
   "dependencies": {
+    "github": "^9.2.0",
     "irc": "^0.5.2",
     "readline": "^1.3.0"
   },

--- a/spec/fto-spec.js
+++ b/spec/fto-spec.js
@@ -1,0 +1,50 @@
+const Behaviors = require('../src/behaviors');
+
+const existingResponse = 'publiclab/existing\n1 => My first fake issue\n2 => My second fake issue';
+const nonexistingReponse = 'publiclab/nonexisting is not a valid repository.';
+
+const mockGithub = {
+  issues: {
+    getForRepo: ({ repo }) => {
+      return new Promise((resolve, reject) => {
+        if (repo == 'existing') {
+          resolve({
+            data: [{
+              number: 1,
+              title: 'My first fake issue'
+            }, {
+              number: 2,
+              title: 'My second fake issue'
+            }]
+          });
+        } else {
+          let err = new Error();
+          err.status = 'Not Found';
+          reject(err);
+        }
+      });
+    }
+  }
+};
+
+describe('FTO Behavior', () => {
+  const botNick = 'testbot';
+  const ftoBehavior = require('../src/behaviors/fto')({ github: mockGithub });
+  const behaviors = new Behaviors(botNick, undefined, [], [ftoBehavior]);
+
+  // console.log(mockGithub.issues.getForRepo('publiclab', 'existing', 'first-timers-only'));
+
+  it('should get existing repository', (done) => {
+    behaviors.getResponse(botNick, 'fto existing').then(response => {
+      expect(response).toBe(existingResponse);
+      done();
+    });
+  });
+
+  it('should get nonexisting repository', (done) => {
+    behaviors.getResponse(botNick, 'fto nonexisting').then(response => {
+      expect(response).toBe(nonexistingReponse);
+      done();
+    });
+  });
+});

--- a/spec/fto-spec.js
+++ b/spec/fto-spec.js
@@ -1,32 +1,9 @@
 const Behaviors = require('../src/behaviors');
+const mockGithub = require('../src/utils').mockGithub;
 
 const emptyResponse = 'You need to mention the name of a repository.';
 const existingResponse = 'publiclab/existing\n1 => My first fake issue\n2 => My second fake issue';
 const nonexistingReponse = 'publiclab/nonexisting is not a valid repository.';
-
-const mockGithub = {
-  issues: {
-    getForRepo: ({ repo }) => {
-      return new Promise((resolve, reject) => {
-        if (repo == 'existing') {
-          resolve({
-            data: [{
-              number: 1,
-              title: 'My first fake issue'
-            }, {
-              number: 2,
-              title: 'My second fake issue'
-            }]
-          });
-        } else {
-          let err = new Error();
-          err.status = 'Not Found';
-          reject(err);
-        }
-      });
-    }
-  }
-};
 
 describe('FTO Behavior', () => {
   const botNick = 'testbot';

--- a/spec/fto-spec.js
+++ b/spec/fto-spec.js
@@ -1,5 +1,6 @@
 const Behaviors = require('../src/behaviors');
 
+const emptyResponse = 'You need to mention the name of a repository.';
 const existingResponse = 'publiclab/existing\n1 => My first fake issue\n2 => My second fake issue';
 const nonexistingReponse = 'publiclab/nonexisting is not a valid repository.';
 
@@ -32,7 +33,12 @@ describe('FTO Behavior', () => {
   const ftoBehavior = require('../src/behaviors/fto')({ github: mockGithub });
   const behaviors = new Behaviors(botNick, undefined, [], [ftoBehavior]);
 
-  // console.log(mockGithub.issues.getForRepo('publiclab', 'existing', 'first-timers-only'));
+  it('should ask user to mention a repository', (done) => {
+    behaviors.getResponse(botNick, 'fto').then(response => {
+      expect(response).toBe(emptyResponse);
+      done();
+    });
+  });
 
   it('should get existing repository', (done) => {
     behaviors.getResponse(botNick, 'fto existing').then(response => {
@@ -44,6 +50,18 @@ describe('FTO Behavior', () => {
   it('should get nonexisting repository', (done) => {
     behaviors.getResponse(botNick, 'fto nonexisting').then(response => {
       expect(response).toBe(nonexistingReponse);
+      done();
+    });
+  });
+
+  it('should get different combinations of repositories', (done) => {
+    behaviors.getResponse(botNick, 'fto nonexisting existing nonexisting').then(response => {
+      expect(response).toBe(`${nonexistingReponse}\n\n${existingResponse}\n\n${nonexistingReponse}`);
+      done();
+    });
+
+    behaviors.getResponse(botNick, 'fto existing nonexisting existing').then(response => {
+      expect(response).toBe(`${existingResponse}\n\n${nonexistingReponse}\n\n${existingResponse}`);
       done();
     });
   });

--- a/spec/fto-spec.js
+++ b/spec/fto-spec.js
@@ -1,5 +1,5 @@
 const Behaviors = require('../src/behaviors');
-const mockGithub = require('../src/utils').mockGithub;
+const mockGithub = require('./test-utils').mockGithub;
 
 const emptyResponse = 'You need to mention the name of a repository.';
 const existingResponse = 'publiclab/existing\n1 => My first fake issue\n2 => My second fake issue';

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -1,0 +1,27 @@
+const mockGithub = {
+  issues: {
+    getForRepo: ({ repo }) => {
+      return new Promise((resolve, reject) => {
+        if (repo == 'existing') {
+          resolve({
+            data: [{
+              number: 1,
+              title: 'My first fake issue'
+            }, {
+              number: 2,
+              title: 'My second fake issue'
+            }]
+          });
+        } else {
+          let err = new Error();
+          err.status = 'Not Found';
+          reject(err);
+        }
+      });
+    }
+  }
+};
+
+module.exports = {
+  mockGithub
+};

--- a/src/behaviors/fto.js
+++ b/src/behaviors/fto.js
@@ -3,16 +3,30 @@ const Behavior = require('../models/behavior');
 
 const github = new Github();
 
-const ftoAction = () => {
+function ftoRepo(repo) {
   return github.issues.getForRepo({
     owner: 'publiclab',
-    repo: 'plots2',
+    repo,
     labels: 'first-timers-only'
   }).then(data => {
     return data.data.reduce((acc, issue) => {
       return acc + `\n${issue.number} => ${issue.title}`;
-    }, '');
+    }, `publiclab/${repo}`);
+  }).catch(err => {
+    if (err.status === 'Not Found') {
+      return `publiclab/${repo} is not a valid repository.`;
+    } else {
+      throw err;
+    }
   });
+}
+
+const ftoAction = (botNick, options) => {
+  if (options.length > 0) {
+    return Promise.all(options.map(ftoRepo)).then(repos => repos.join('\n\n'));
+  } else {
+    return 'You need to mention the name of a repository.';
+  }
 };
 
 module.exports = new Behavior('message', ftoAction, 'fto');

--- a/src/behaviors/fto.js
+++ b/src/behaviors/fto.js
@@ -4,14 +4,14 @@ const Behavior = require('../models/behavior');
 const github = new Github();
 
 const ftoAction = () => {
-  github.issues.getForRepo({
+  return github.issues.getForRepo({
     owner: 'publiclab',
     repo: 'plots2',
     labels: 'first-timers-only'
   }).then(data => {
-    data.data.forEach(issue => {
-      console.log(`${issue.number} => ${issue.title}`);
-    });
+    return data.data.reduce((acc, issue) => {
+      return acc + `\n${issue.number} => ${issue.title}`;
+    }, '');
   });
 };
 

--- a/src/behaviors/fto.js
+++ b/src/behaviors/fto.js
@@ -1,32 +1,31 @@
-const Github = require('github');
 const Behavior = require('../models/behavior');
 
-const github = new Github();
-
-function ftoRepo(repo) {
-  return github.issues.getForRepo({
-    owner: 'publiclab',
-    repo,
-    labels: 'first-timers-only'
-  }).then(data => {
-    return data.data.reduce((acc, issue) => {
-      return acc + `\n${issue.number} => ${issue.title}`;
-    }, `publiclab/${repo}`);
-  }).catch(err => {
-    if (err.status === 'Not Found') {
-      return `publiclab/${repo} is not a valid repository.`;
-    } else {
-      throw err;
-    }
-  });
-}
-
-const ftoAction = (botNick, options) => {
-  if (options.length > 0) {
-    return Promise.all(options.map(ftoRepo)).then(repos => repos.join('\n\n'));
-  } else {
-    return 'You need to mention the name of a repository.';
+module.exports = ({ github }) => {
+  function ftoRepo(repo) {
+    return github.issues.getForRepo({
+      owner: 'publiclab',
+      repo,
+      labels: 'first-timers-only'
+    }).then(data => {
+      return data.data.reduce((acc, issue) => {
+        return acc + `\n${issue.number} => ${issue.title}`;
+      }, `publiclab/${repo}`);
+    }).catch(err => {
+      if (err.status === 'Not Found') {
+        return `publiclab/${repo} is not a valid repository.`;
+      } else {
+        throw err;
+      }
+    });
   }
-};
 
-module.exports = new Behavior('message', ftoAction, 'fto');
+  const ftoAction = (botNick, options) => {
+    if (options.length > 0) {
+      return Promise.all(options.map(ftoRepo)).then(repos => repos.join('\n\n'));
+    } else {
+      return 'You need to mention the name of a repository.';
+    }
+  };
+
+  return new Behavior('message', ftoAction, 'fto');
+};

--- a/src/behaviors/fto.js
+++ b/src/behaviors/fto.js
@@ -10,7 +10,7 @@ const ftoAction = () => {
     labels: 'first-timers-only'
   }).then(data => {
     data.data.forEach(issue => {
-      console.log(`${issue.number} => ${issue.title}`)
+      console.log(`${issue.number} => ${issue.title}`);
     });
   });
 };

--- a/src/behaviors/fto.js
+++ b/src/behaviors/fto.js
@@ -1,0 +1,18 @@
+const Github = require('github');
+const Behavior = require('../models/behavior');
+
+const github = new Github();
+
+const ftoAction = () => {
+  github.issues.getForRepo({
+    owner: 'publiclab',
+    repo: 'plots2',
+    labels: 'first-timers-only'
+  }).then(data => {
+    data.data.forEach(issue => {
+      console.log(`${issue.number} => ${issue.title}`)
+    });
+  });
+};
+
+module.exports = new Behavior('message', ftoAction, 'fto');

--- a/src/behaviors/index.js
+++ b/src/behaviors/index.js
@@ -54,8 +54,6 @@ class Behaviors {
             this.client.sendMessage(to, response);
           }
         }
-      }).catch(err => {
-        console.error(err);
       });
     });
   }
@@ -78,6 +76,8 @@ class Behaviors {
         // If the message was not meant for the bot
         return undefined;
       }
+    }).catch(err => {
+      console.error(err);
     });
   }
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -4,6 +4,7 @@ const Behaviors = require('./behaviors');
 
 const greetBehavior = require('./behaviors/greet');
 const helpBehavior = require('./behaviors/help').helpBehavior;
+const ftoBehavior = require('./behaviors/fto');
 
 // Read file synchronously because we'd need this object in later steps anyway.
 const config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
@@ -25,7 +26,8 @@ const joinBehaviors = [
 ];
 
 const messageBehaviors = [
-  helpBehavior
+  helpBehavior,
+  ftoBehavior
 ];
 
 const behaviors = new Behaviors(config.name, client, joinBehaviors, messageBehaviors);

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,16 +1,20 @@
 const fs = require('fs');
+const Github = require('github');
 
 const Behaviors = require('./behaviors');
 
+const state = {
+  github: new Github()
+};
+
 const greetBehavior = require('./behaviors/greet');
 const helpBehavior = require('./behaviors/help').helpBehavior;
-const ftoBehavior = require('./behaviors/fto');
+const ftoBehavior = require('./behaviors/fto')(state);
 
 // Read file synchronously because we'd need this object in later steps anyway.
 const config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
 
 let client;
-
 if (process.env.TEST) {
   const CliClient = require('./interfaces/cli');
   client = new CliClient(config.name);

--- a/src/interfaces/cli.js
+++ b/src/interfaces/cli.js
@@ -15,8 +15,7 @@ class CliClient {
   }
 
   sendMessage(channel, message) {
-    console.log(`[${this.nick} => ${channel}]\n${message}`);
-    console.log(`[${channel} => ${this.nick}]`);
+    console.log(message);
   }
 
   addMessageHandler(actions) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,32 @@ function remove(array, element) {
   array.splice(array.indexOf(element), 1);
 }
 
+const mockGithub = {
+  issues: {
+    getForRepo: ({ repo }) => {
+      return new Promise((resolve, reject) => {
+        if (repo == 'existing') {
+          resolve({
+            data: [{
+              number: 1,
+              title: 'My first fake issue'
+            }, {
+              number: 2,
+              title: 'My second fake issue'
+            }]
+          });
+        } else {
+          let err = new Error();
+          err.status = 'Not Found';
+          reject(err);
+        }
+      });
+    }
+  }
+};
+
 module.exports = {
   contains,
-  remove
+  remove,
+  mockGithub
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,32 +6,7 @@ function remove(array, element) {
   array.splice(array.indexOf(element), 1);
 }
 
-const mockGithub = {
-  issues: {
-    getForRepo: ({ repo }) => {
-      return new Promise((resolve, reject) => {
-        if (repo == 'existing') {
-          resolve({
-            data: [{
-              number: 1,
-              title: 'My first fake issue'
-            }, {
-              number: 2,
-              title: 'My second fake issue'
-            }]
-          });
-        } else {
-          let err = new Error();
-          err.status = 'Not Found';
-          reject(err);
-        }
-      });
-    }
-  }
-};
-
 module.exports = {
   contains,
-  remove,
-  mockGithub
+  remove
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@ acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
+agent-base@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
+  dependencies:
+    extend "~3.0.0"
+    semver "~5.0.1"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -142,7 +149,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-debug@^2.1.1:
+debug@2, debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -327,6 +334,10 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
+extend@3, extend@~3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -354,6 +365,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+follow-redirects@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.7.tgz#34b90bab2a911aa347571da90f22bd36ecd8a919"
+  dependencies:
+    debug "^2.2.0"
+    stream-consume "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -367,6 +385,15 @@ generate-object-property@^1.1.0:
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
   dependencies:
     is-property "^1.0.0"
+
+github@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
+  dependencies:
+    follow-redirects "0.0.7"
+    https-proxy-agent "^1.0.0"
+    mime "^1.2.11"
+    netrc "^0.1.4"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
   version "7.1.2"
@@ -403,6 +430,14 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+https-proxy-agent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
+  dependencies:
+    agent-base "2"
+    debug "2"
+    extend "3"
 
 iconv@~2.2.1:
   version "2.2.3"
@@ -561,6 +596,10 @@ lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+mime@^1.2.11:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -592,6 +631,10 @@ nan@^2.3.3, nan@^2.3.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+netrc@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
 node-icu-charset-detector@~0.2.0:
   version "0.2.0"
@@ -748,6 +791,10 @@ safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+semver@~5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
+
 shelljs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
@@ -763,6 +810,10 @@ slice-ansi@0.0.4:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+stream-consume@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Sample Output (As of now):

```
➜  plotsbot git:(minor-2) ✗ TEST=true node src/bot
Bot is running in testing mode.
[ryzokuken => plotsbot-ryzokuken]
fto
1451 => Adjust subscription_mailer to use rusers table
1418 => Add more functional tests to each method in Search API
1405 => Fix "like" list URL on notes and wiki pages
171 => rss feeds empty for banned users
```

@jywarren @ananyo2012 I personally feel that promises are a very crucial part of the bot, because if we do not use promises, the calls would be blocking, which would not allow the bot to work at its full potential.

However, the inclusion of a promise-based workflow makes our job difficult at the same time. Because the promises aren't handled by the behavior itself but the rest of the logic which is completely independent of the bot, it would not understand how to deal with promise resolution and rejection.  
**For eg:** The code from this issue can return a promise which would yield an object. However, the `addMessageHandler` function (the function which actually gets the value) is completely behavior agnostic and has no idea how to use that object to make a valid message.

I welcome your suggestions on this. Here is a possible solution I came up with:

If a particular behavior returns a promise, it is mandatory to also include two other functions inside the object. These two functions, (can be called `onPromiseResolve` and `onPromiseReject`) take the object yielded by the Promise as an argument and return the string that can be sent as message, and takes the error object and takes care of it (log it in our case) respectively. For functions that return a normal string value, it would not be required to define such a function as a default value would be set of these functions which would be good enough only for functions that return a string value and not an object. It could be somewhere on the lines of:

```js
function onPromiseResolve(value) {
  return value;
}
```

**OR BETTER**

```js
const onPromiseResolve = data => data;
```

What do you think about this?

Also, I think it would be more appropriate for behaviors to return classes that extend `Behavior` rather than objects. This way, we would be able to supply some initial input from `bot.js` to the specific behavior through its constructor.  
**Eg:** This particular issue defines an instance of class Github inside the behavior. However, it would be more appropriate to define such an object inside `bot.js`, configure it with the proper credentials once and then pass it as an argument to *ALL* github-based issues.