### PR TITLE
Add short-term memory to the greet behavior

### DIFF
--- a/src/behaviors/greet.js
+++ b/src/behaviors/greet.js
@@ -1,7 +1,13 @@
 const Behavior = require('../models/behavior');
+const utils = require('../utils');
+
+let greeted = [];
 
 const greetAction = (channel, username, botNick) => {
-  return `Welcome to Publiclab, ${username}! For a quick walkthrough, send the message: \`${botNick} help\``;
+  if(!utils.contains(greeted, username)) {
+    greeted.push(username);
+    return `Welcome to Publiclab, ${username}! For a quick walkthrough, send the message: \`${botNick} help\``;
+  }
 };
 
 module.exports = new Behavior('join', greetAction);


### PR DESCRIPTION
```irc
* Now talking on #publiclab-testing
<plotsbot> Welcome to Publiclab, ryzokuken! For a quick walkthrough, send the message: `plotsbot help`
<plotsbot-ryzokuken> Welcome to Publiclab, ryzokuken! For a quick walkthrough, send the message: `plotsbot-ryzokuken help`
<ryzokuken> greeted me once.
* You have left channel #publiclab-testing
* Now talking on #publiclab-testing
<plotsbot> Welcome to Publiclab, ryzokuken! For a quick walkthrough, send the message: `plotsbot help`
<ryzokuken> won't greet me twice.
<ryzokuken> awesome.
```