### PR TITLE
Add a helpful npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This interface can be used instead of the default interface by setting the envir
 #### Example:
 
 ```
-➜  plotsbot git:(master) TEST=true node bot.js
+➜  plotsbot git:(master) TEST=true npm start
 Bot is running in testing mode.
 [ryzokuken => plotsbot-ryzokuken]
 help
@@ -126,13 +126,13 @@ In order to install all node modules the package depends on, just run `yarn` or 
 
 ## Run
 
-Now that you're ready, run the bot by running the command, `node bot.js`.
+Now that you're ready, run the bot by running the command, `npm start`.
 
 In development, running the bot using nodemon is recommended. Install nodemon by running `npm install -g nodemon` or `yarn global add nodemon` and then execute the bot using `nodemon bot.js`. Nodemon will listen for changes to the files and rerun the bot automatically whenever you make a change.
 
 ## Experimentation
 
-In order to experiment locally on the bot, you need to set the `TEST` environment variable to be true. Running the bot using `TEST=true node bot.js` will work.
+In order to experiment locally on the bot, you need to set the `TEST` environment variable to be true. Running the bot using `TEST=true npm start` will work.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "./node_modules/.bin/eslint .",
     "lint-fix": "./node_modules/.bin/eslint --fix .",
     "test": "./node_modules/.bin/jasmine",
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "start": "node ."
   }
 }


### PR DESCRIPTION
This would help us abstract away the startup processes of the bot, and also increase consistency (next time the start command changes, all we need to do is change the `package.json`, and contributors can continue to use `npm start`.