### PR TITLE
disable "nobody's around" message #108

### DIFF
--- a/spec/unresponsive-spec.js
+++ b/spec/unresponsive-spec.js
@@ -2,14 +2,14 @@ const Behaviors = require('../src/behaviors');
 
 const responseTime = 100;
 const offsetTime = 100;
-const standardResponse = 'Hi, looks like nobody\'s around just now. If you have a question, you can post it a https://publiclab.org/questions, or if you need help with a software issue, you can open an issue at https://github.com/publiclab/plots2/issues/new -- thanks!';
+const standardResponse = '';
 
 describe('Unresponsive Behavior', () => {
   const botNick = 'testbot';
   const unresponsiveBehavior = require('../src/behaviors/unresponsive')({ responseTime, offsetTime });
   const behaviors = new Behaviors(botNick, undefined, [], [unresponsiveBehavior]);
 
-  it('should print the message if nobody responds for 10 ms', (done) => {
+  it('should not print any message if nobody responds for 10 ms', (done) => {
     behaviors.getResponse('user', botNick, 'hello').then(response => {
       expect(response).toBe(standardResponse);
       done();

--- a/src/behaviors/unresponsive.js
+++ b/src/behaviors/unresponsive.js
@@ -10,7 +10,7 @@ module.exports = ({ responseTime, offsetTime }) => {
     return new Promise((resolve, reject) => {
       currentTimeout = setTimeout(() => {
         currentTimeout = undefined;
-        resolve('Hi, looks like nobody\'s around just now. If you have a question, you can post it a https://publiclab.org/questions, or if you need help with a software issue, you can open an issue at https://github.com/publiclab/plots2/issues/new -- thanks!');
+        resolve('');
       }, responseTime);
 
       setTimeout(() => {


### PR DESCRIPTION
I've described in #108 how plotbot always insists on getting the last word. In this pull request I'm attempting to disable the "nobody's around" message. We can rethink this feature in the future.